### PR TITLE
add htop and rsync to image based on request from workshop admins

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,2 +1,4 @@
 emacs
+rsync
+htop
 jed


### PR DESCRIPTION
Based on request, adding `htop` and `rsync`

@sunu can you quick review and merge, and then I can test the images on the hub and make the required changes to the `infrastructure` repo to update the default images.

Thanks!